### PR TITLE
Mono fx update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- feat: add support for Flutter on the web
+
 # 2.0.1
 
 - fix: prioritise `scope` provided in widget configuration


### PR DESCRIPTION
This PR logs the change `feat: add support for Flutter on the web` to the changelog.